### PR TITLE
Assistant checkpoint: Update toast color to green for normal messages

### DIFF
--- a/client/src/components/ui/toast.tsx
+++ b/client/src/components/ui/toast.tsx
@@ -27,7 +27,7 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: "border bg-white text-[#e80113] shadow-lg",
+        default: "border bg-white text-[#22c55e] shadow-lg",
         destructive:
           "destructive group border-[#e80113] bg-white text-[#e80113]",
       },


### PR DESCRIPTION
Assistant generated file changes:
- client/src/components/ui/toast.tsx: Update toast color to green for normal messages

---

User prompt:

通常のメッセージは緑色にして

Replit-Commit-Author: Assistant
Replit-Commit-Session-Id: d23e71e1-8be7-4da0-a928-962c2d24758b